### PR TITLE
Activate and focus active pane after compile

### DIFF
--- a/lib/coffee-compile.coffee
+++ b/lib/coffee-compile.coffee
@@ -45,6 +45,7 @@ module.exports =
     atom.workspace.openUriInPane(uri, pane, {}).done (coffeeCompileView) ->
       if coffeeCompileView instanceof CoffeeCompileView
         coffeeCompileView.renderCompiled()
+        activePane.activate()
 
         if atom.config.get('coffee-compile.compileOnSave')
           coffeeCompileView.saveCompiled()


### PR DESCRIPTION
this is really uncomfortable to switch each time between views. especially because you can't edit compiled code because it is read-only
