### PR TITLE
Add source.coffee.jsx to list of selectors.

### DIFF
--- a/lib/providers/coffee-provider.coffee
+++ b/lib/providers/coffee-provider.coffee
@@ -6,6 +6,7 @@ module.exports =
   id: 'coffee-compile'
   selector: [
     'source.coffee'
+    'source.coffee.jsx'
     'source.litcoffee'
     'text.plain'
     'text.plain.null-grammar'


### PR DESCRIPTION
This fixes compiling of cjsx with orktes/atom-react grammar selector. 

Previously exited with "Coffee compile: Invalid language" for cjsx files with above grammar installed.