### PR TITLE
Use editor-local versions of CoffeeScript and coffee-react-transform…

### DIFF
--- a/lib/providers/coffee-provider.coffee
+++ b/lib/providers/coffee-provider.coffee
@@ -1,6 +1,11 @@
-coffee         = require 'coffee-script'
 configManager  = require '../config-manager'
-cjsx_transform = null
+resolve        = require 'resolve'
+path           = require 'path'
+
+scopedRequire = (basedir, modName) ->
+  rst = null
+  try rst = path.dirname(resolve.sync(modName, { basedir }))
+  if rst then require "#{rst}" else require modName
 
 module.exports =
   id: 'coffee-compile'
@@ -13,15 +18,16 @@ module.exports =
   ]
   compiledScope: 'source.js'
   preCompile: (code, editor) ->
+    cjsx_transform = null
     if configManager.get('compileCjsx')
-      unless cjsx_transform
-        cjsx_transform = require 'coffee-react-transform'
+      cjsx_transform = scopedRequire path.dirname(editor.getPath()), 'coffee-react-transform'
 
       code = cjsx_transform code
 
     return code
 
   compile: (code, editor) ->
+    coffee = scopedRequire path.dirname(editor.getPath()), 'coffee-script'
     literate = editor.getGrammar().scopeName is "source.litcoffee"
 
     bare  = configManager.get('noTopLevelFunctionWrapper')

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -92,7 +92,7 @@ module.exports =
     @compileToFile(sourceEditor) if shouldWriteToFile
 
   buildCoffeeCompileEditor: (sourceEditor) ->
-    previewEditor = atom.workspace.buildTextEditor()
+    previewEditor = atom.workspace.buildTextEditor(autoHeight: true)
 
     shouldCompileToFile = sourceEditor? and fsUtil.isPathInSrc(sourceEditor.getPath()) and
       pluginManager.isEditorLanguageSupported(sourceEditor, true)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "coffee-react-transform": "3.1.0",
     "coffee-script": "1.10.0",
+    "resolve": "^1.1.7",
     "season": "^5.3.0"
   },
   "consumedServices": {


### PR DESCRIPTION
…, if available.

coffee-script and coffee-react-transform will be loaded from the node_modules nearest to the source file being edited, instead of from the Atom package.

I made this modification because some of my projects are now using CoffeeScript 1.11, which allows ES2015 import/export directives. The builtin CoffeeScript treats them as syntax errors. As CoffeeScript moves forward it's better that one not be stuck with whichever version is bundled with the compiler plugin, thus let's dynamically load it from the project.
- Added dependency on node-resolve
- Added scopedResolve function to coffee-provider
